### PR TITLE
CacheRemovingBehavior RemovingKey Logic

### DIFF
--- a/Core.Application/Pipelines/Caching/CacheRemovingBehavior.cs
+++ b/Core.Application/Pipelines/Caching/CacheRemovingBehavior.cs
@@ -42,13 +42,14 @@ public class CacheRemovingBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
 
                 await _cache.RemoveAsync(request.CacheGroupKey, cancellationToken);
                 await _cache.RemoveAsync(key: $"{request.CacheGroupKey}SlidingExpiration", cancellationToken);
+            } 
+            else 
+            {
+                if(request.CacheKey != null)
+                    await _cache.RemoveAsync(request.CacheKey, cancellationToken);
             }
         }
-
-        if (request.CacheKey!=null)
-        {
-            await _cache.RemoveAsync(request.CacheKey,cancellationToken);
-        }
+        
         return response;
     }
 }

--- a/Core.Application/Pipelines/Logging/LoggingBehavior.cs
+++ b/Core.Application/Pipelines/Logging/LoggingBehavior.cs
@@ -35,7 +35,7 @@ public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, 
         LogDetail logDetail
             = new()
             {
-                MethodName = next.Method.Name,
+                MethodName = request.GetType().Name,
                 Parameters = logParameters,
                 User = _httpContextAccessor.HttpContext.User.Identity?.Name??"?"
             };


### PR DESCRIPTION
The issue:
When a cache group key exists, deleting it automatically removes all associated single keys. However, the code was still attempting to delete single keys afterward, which is redundant.

The solution:
I updated the logic so that single key deletion only happens when no cache group key exists. This prevents unnecessary operations and improves efficiency.